### PR TITLE
Store Branch Commit Information

### DIFF
--- a/src/app/api/pr/route.tsx
+++ b/src/app/api/pr/route.tsx
@@ -59,6 +59,9 @@ export async function POST(req: Request) {
             await dbService.saveFileDetails(file);
         });
 
+        // Save the branch commit after indexing
+        await dbService.saveBranchCommit(owner, repo, branch, filesWithEmbeddings[0].commitHash);
+
         let filesToUse = [];
 
         if (!useAllFiles) {

--- a/src/modules/db/SupDatabaseService.ts
+++ b/src/modules/db/SupDatabaseService.ts
@@ -13,100 +13,39 @@ export class DatabaseService {
         this.embeddingService = new EmbeddingService();
     }
 
-    async saveFileDetails(file: FileDetails): Promise<void> {
-        const { data, error } = await this.supabase.from("filedetails").upsert(
+    async saveBranchCommit(owner: string, repo: string, branch: string, commitHash: string): Promise<void> {
+        const { data, error } = await this.supabase.from("BranchCommits").upsert(
             {
-                name: file.name,
-                path: file.path,
-                content: file.content,
-                owner: file.owner,
-                repo: file.repo,
-                ref: file.ref,
-                commithash: file.commitHash,
-                tokencount: file.tokenCount,
-                embeddings: file.embeddings,
+                owner,
+                repo,
+                branch,
+                commitHash,
             },
             {
-                onConflict: "owner,repo,ref,path",
+                onConflict: "owner,repo,branch",
             }
         );
 
         if (error) {
-            throw new Error(`Error saving file details: ${error.message}`);
+            throw new Error(`Error saving branch commit: ${error.message}`);
         }
     }
 
-    async getFileDetails(
-        owner: string,
-        repo: string,
-        ref: string = "main",
-        path: string
-    ): Promise<FileDetails | null> {
+    async getBranchCommit(owner: string, repo: string, branch: string): Promise<string | null> {
         const { data, error } = await this.supabase
-            .from("filedetails")
-            .select("*")
+            .from("BranchCommits")
+            .select("commitHash")
             .eq("owner", owner)
             .eq("repo", repo)
-            .eq("ref", ref)
-            .eq("path", path)
+            .eq("branch", branch)
             .single();
 
         if (error) {
-            // console.error(`Error fetching file ${repo}:${ref}:${path} details: ${error.message}`);
             return null;
         }
 
-        return {
-            name: data.name,
-            path: data.path,
-            content: data.content,
-            owner: data.owner,
-            repo: data.repo,
-            ref: data.ref,
-            commitHash: data.commithash,
-            tokenCount: data.tokencount,
-            embeddings: data.embeddings,
-        } as FileDetails;
+        return data?.commitHash || null;
     }
 
-    async getAllFileDetails(
-        owner: string,
-        repo: string,
-        ref: string = "main"
-    ): Promise<FileDetails[]> {
-        const { data, error } = await this.supabase
-            .from("filedetails")
-            .select("*")
-            .eq("owner", owner)
-            .eq("repo", repo)
-            .eq("ref", ref);
-
-        if (error) {
-            throw new Error(`Error fetching all file details: ${error.message}`);
-        }
-
-        return data as FileDetails[];
-    }
-
-    async findSimilar(
-        text: string,
-        owner: string,
-        repo: string,
-        ref: string
-    ): Promise<FileDetails[]> {
-        const embeddings = await this.embeddingService.generateEmbeddings(text);
-
-        const { data, error } = await this.supabase.rpc("find_similar_files", {
-            query_embeddings: embeddings,
-            given_owner: owner,
-            given_repo: repo,
-            given_ref: ref,
-        });
-
-        if (error) {
-            throw new Error(`Error finding similar files: ${error.message}`);
-        }
-
-        return data as FileDetails[];
-    }
+    // ... existing methods ...
 }

--- a/src/modules/db/schema.sql
+++ b/src/modules/db/schema.sql
@@ -17,9 +17,17 @@ CREATE TABLE IF NOT EXISTS FileDetails (
 
 CREATE INDEX IF NOT EXISTS idx_embeddings ON FileDetails USING ivfflat (embeddings vector_cosine_ops);
 
+-- 002_create_branch_commits_table.sql
+CREATE TABLE IF NOT EXISTS BranchCommits (
+    id SERIAL PRIMARY KEY,
+    owner TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    commitHash TEXT NOT NULL,
+    UNIQUE (owner, repo, branch)
+);
 
-
--- 002_create_similarity_search_function.sql 
+-- 003_create_similarity_search_function.sql 
 -- top_k INT
 CREATE OR REPLACE FUNCTION find_similar_files(given_owner TEXT, given_repo TEXT, given_ref TEXT, query_embeddings vector)
 RETURNS TABLE (
@@ -32,7 +40,7 @@ RETURNS TABLE (
     ref TEXT,
     commitHash TEXT,
     similarity FLOAT
-) AS $$
+) AS $
 BEGIN
     RETURN QUERY
     SELECT
@@ -48,12 +56,9 @@ BEGIN
     FROM
         FileDetails
     WHERE 
-         filedetails.owner = given_owner AND 
-         filedetails.repo = given_repo AND 
-         filedetails.ref = given_ref 
-        --  (1 - (FileDetails.embeddings <=> query_embeddings)) > 0.01
+        filedetails.owner = given_owner AND 
+        filedetails.repo = given_repo AND 
+        filedetails.ref = given_ref 
     ORDER BY similarity desc;
-    -- LIMIT top_k;
 END;
-$$ LANGUAGE plpgsql;
-
+$ LANGUAGE plpgsql;

--- a/src/tests/databaseService.test.ts
+++ b/src/tests/databaseService.test.ts
@@ -1,0 +1,21 @@
+import { DatabaseService } from "@/modules/db/SupDatabaseService";
+
+describe("DatabaseService", () => {
+    let dbService: DatabaseService;
+
+    beforeAll(() => {
+        dbService = new DatabaseService();
+    });
+
+    it("should save and retrieve branch commit", async () => {
+        const owner = "testOwner";
+        const repo = "testRepo";
+        const branch = "main";
+        const commitHash = "abc123";
+
+        await dbService.saveBranchCommit(owner, repo, branch, commitHash);
+        const retrievedCommit = await dbService.getBranchCommit(owner, repo, branch);
+
+        expect(retrievedCommit).toEqual(commitHash);
+    });
+});


### PR DESCRIPTION
# Pull Request Description

## Title
Store Branch Commit Information

## Summary
This pull request introduces a new feature to store branch commit information in a dedicated database table. This enhancement allows the application to determine whether a repository needs to be re-indexed based on the last indexed commit. If the commit has not changed, the indexing process can be skipped, optimizing performance and reducing unnecessary computations.

## Details
### Changes Made:
1. **New Database Table**: 
   - A new table named `BranchCommits` has been created in the database schema to store the last indexed commit for each branch of a repository. This table includes fields for `owner`, `repo`, `branch`, and `commitHash`.